### PR TITLE
Add List and Retrieve methods to Candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,28 @@ const Checkr = new checkr(API_KEY);
 Candidates
 -----------
 
+##### `list()`
+
+Returns the list of all existing candidates.
+
+```javascript
+  checkr.Candidates
+    .list()
+    .then(res => console.log(res))
+    .catch(err => console.log(err));
+```
+
+##### `retrieve(id)`
+
+Retrieves a particular candidate, given the `id`.
+
+```javascript
+  checkr.Candidates
+    .retrieve(id)
+    .then(res => console.log(res))
+    .catch(err => console.log(err));
+```
+
 ##### `create(params)`
 
 

--- a/src/candidates.js
+++ b/src/candidates.js
@@ -26,6 +26,41 @@ const schema = Joi.object().keys({
 
 const candidates = options => {
   return {
+    retrieve: async id => {
+      if (!id || id === undefined || id === null) {
+        throw new Error('List Candidates - Missing or invalid ID');
+      }
+      try {
+        const res = await axios({
+          method: 'get',
+          url: `${options.baseUrl}/${options.apiVersion}/candidates/${id}`,
+          auth: {
+            username: options.apiKey,
+            password: ''
+          }
+        });
+        return res.data;
+      } catch (error) {
+        throw { code: error.response.status, data: error.response.data };
+      }
+    },
+
+    list: async () => {
+      try {
+        const res = await axios({
+          method: 'get',
+          url: `${options.baseUrl}/${options.apiVersion}/candidates`,
+          auth: {
+            username: options.apiKey,
+            password: ''
+          }
+        });
+        return res.data;
+      } catch (error) {
+        throw { code: error.response.status, data: error.response.data };
+      }
+    },
+
     create: async params => {
 
       const validation = Joi.validate(params, schema);
@@ -85,7 +120,7 @@ const candidates = options => {
       } catch (error) {
         throw { code: error.response.status, data: error.response.data };
       }
-    }
+    },
   };
 };
 

--- a/tests/candidates.test.js
+++ b/tests/candidates.test.js
@@ -55,4 +55,40 @@ describe('## Candidates', () => {
         });
     });
   });
+  describe('# LIST', () => {
+    it('should list all candidates', done => {
+      checkr.Candidates
+        .list()
+        .then(res => {
+          expect(res).to.have.property('data');
+          expect(res.data).to.be.an('array')
+          done();
+        })
+        .catch(err => {
+          if (err) {
+            console.log(err);
+          }
+          expect(err).to.be.null;
+          done();
+        });
+    });
+  });
+  describe('# RETRIEVE', () => {
+    it('should retrieve an existing candidate', done => {
+      checkr.Candidates
+        .retrieve( candidateId )
+        .then(res => {
+          expect(res).to.have.property('id');
+          expect(res.first_name).to.equal('Jane');
+          done();
+        })
+        .catch(err => {
+          if (err) {
+            console.log(err);
+          }
+          expect(err).to.be.null;
+          done();
+        });
+    });
+  });
 });


### PR DESCRIPTION
I've found the `list` and `retrieve` methods  in the [Checkr Docs](https://docs.checkr.com/#candidate) were missing in the library and i've thought it could be useful using this api, so i've added and tested the methods with a valid `API_KEY` and it passed, here is the POC.

<img width="503" alt="screen shot 2017-10-26 at 14 41 49" src="https://user-images.githubusercontent.com/4107768/32056831-923430ee-ba5d-11e7-802c-3b77f843fac6.png">

So if you think that it could be useful to have this in this library it would be great.

In the future it could be useful passing filters to the `list` method such as filter by `email, full_name, adjudication`... according to the docs.